### PR TITLE
Pin urllib3 as version >= 2.0.0 doesn't work on Amazon

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     click
     pybuildkite
     PyGithub<2.0.0
+    urllib3<2.0.0
     requests
 
 [options.entry_points]


### PR DESCRIPTION
Failing with
```
ImportError: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'OpenSSL 1.0.2k-fips  26 Jan 2017'. See: https://github.com/urllib3/urllib3/issues/2168
```