### PR TITLE
fix(github): update PyGithub token usage for auth param

### DIFF
--- a/report_aggregator/nightly_github.py
+++ b/report_aggregator/nightly_github.py
@@ -44,7 +44,7 @@ def download_nightly_results(
     base_dir: Path, repo_slug: str = consts.REPO_SLUG, timedelta_mins: int = consts.TIMEDELTA_MINS
 ) -> None:
     """Download results from all recent nightly jobs."""
-    github_obj = github.Github(login_or_token=consts.GITHUB_TOKEN)
+    github_obj = github.Github(auth=github.Auth.Token(consts.GITHUB_TOKEN))
     repo_obj = github_obj.get_repo(repo_slug)
     started_from = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
         minutes=timedelta_mins

--- a/report_aggregator/regression_github.py
+++ b/report_aggregator/regression_github.py
@@ -55,7 +55,7 @@ def download_testrun_results(
     timedelta_mins: int = SEARCH_PAST_MINS,
 ) -> None:
     """Download results from all recent nightly jobs."""
-    github_obj = github.Github(login_or_token=consts.GITHUB_TOKEN)
+    github_obj = github.Github(auth=github.Auth.Token(consts.GITHUB_TOKEN))
     repo_obj = github_obj.get_repo(repo_slug)
     started_from = datetime.datetime.now(tz=datetime.timezone.utc) - datetime.timedelta(
         minutes=timedelta_mins


### PR DESCRIPTION
Switch from deprecated `login_or_token` to the new `auth` parameter with `github.Auth.Token` in both nightly and regression result downloaders.