### PR TITLE
fix(publisher): handle XFAIL statusDetails more robustly

### DIFF
--- a/report_aggregator/publisher.py
+++ b/report_aggregator/publisher.py
@@ -238,7 +238,9 @@ def overwrite_statuses(results_dir: Path) -> None:
         with open(result_json, encoding="utf-8") as in_fp:
             result = json.load(in_fp)
 
-        if result["status"] == "skipped" and "XFAIL reason" in result["statusDetails"]["message"]:
+        if result["status"] == "skipped" and result.get("statusDetails", {}).get(
+            "message", ""
+        ).startswith("XFAIL"):
             result["status"] = "failed" if result["uuid"] in teardown_failures else "broken"
             overwrite = True
         elif result["status"] == "broken":


### PR DESCRIPTION
Update status overwrite logic to use .startswith("XFAIL") instead of checking for "XFAIL reason" substring. The substring changed between supported pytest versions.