### PR TITLE
refactor: update skipped command groups in coverage_publisher

### DIFF
--- a/report_aggregator/coverage_publisher.py
+++ b/report_aggregator/coverage_publisher.py
@@ -15,10 +15,10 @@ LOGGER = logging.getLogger(__name__)
 SKIPPED = (
     "--out-file",
     "--testnet-magic",
-    "--mainnet",
-    "--cardano-mode",
+    "compatible",
     "create-cardano",
-    "help",
+    "create-testnet-data",
+    "legacy",
 )
 
 


### PR DESCRIPTION
Expanded and revised the SKIPPED tuple to include also command groups "compatible", "create-testnet-data" and "legacy", and removed entries ("--mainnet", "--cardano-mode", "help") that are already filtered out by the cli-coverage tool.