### PR TITLE
fix: extract step id from artifact name instead of using positional index

### DIFF
--- a/report_aggregator/nightly_github.py
+++ b/report_aggregator/nightly_github.py
@@ -73,10 +73,11 @@ def download_nightly_results(
                 LOGGER.warning("Skipping run with unexpected artifacts")
                 continue
 
-            for step, result_artifact in enumerate(result_artifacts, start=1):
+            for result_artifact in result_artifacts:
                 a_dest_dir = dest_dir
                 if has_steps:
-                    a_dest_dir = dest_dir / f"{consts.STEPS_BASE}{step}"
+                    step_id = result_artifact.name[len(consts.RESULTS_ARTIFACT_NAME) :].lstrip("-")
+                    a_dest_dir = dest_dir / step_id
                 a_dest_dir.mkdir(parents=True, exist_ok=True)
 
                 artifacts_github.process_result_artifact(

--- a/report_aggregator/regression_github.py
+++ b/report_aggregator/regression_github.py
@@ -87,16 +87,17 @@ def download_testrun_results(
             result_artifacts = list(
                 artifacts_github.get_result_artifacts(run_artifacts=run_artifacts)
             )
-            has_steps = len(result_artifacts) > 1
+            has_steps = result_artifacts and ("step" in result_artifacts[0].name)
 
-            if has_steps and "step" not in result_artifacts[0].name:
+            if len(result_artifacts) > 1 and not has_steps:
                 LOGGER.warning("Skipping run with unexpected artifacts")
                 continue
 
-            for step, artifact in enumerate(result_artifacts, start=1):
+            for artifact in result_artifacts:
                 dest_dir = base_dest_dir / str(cur_run.run_number)
                 if has_steps:
-                    dest_dir = dest_dir / f"{consts.STEPS_BASE}{step}"
+                    step_id = artifact.name[len(consts.RESULTS_ARTIFACT_NAME) :].lstrip("-")
+                    dest_dir = dest_dir / step_id
                 dest_dir.mkdir(parents=True, exist_ok=True)
 
                 artifacts_github.process_result_artifact(


### PR DESCRIPTION


When a step artifact is missing (e.g. step2 fails), enumerate() would assign wrong step numbers to subsequent artifacts. Now the step identifier is parsed from the artifact name, preserving correct mapping. Also align regression has_steps check with nightly logic.